### PR TITLE
Using more standardised rulings

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,5 @@
 module.exports = {
-  extends: [
-    'eslint:recommended',
-    'plugin:react/recommended'
-  ],
+  extends: ['eslint:recommended', 'plugin:react/recommended'],
   env: {
     browser: true,
     es6: true,
@@ -22,18 +19,14 @@ module.exports = {
       jsx: true
     }
   },
-  plugins: [
-    'react'
-  ],
+  plugins: ['react'],
   settings: {
     react: {
       createClass: 'createReactClass',
       pragma: 'React',
       version: '16.0'
     },
-    propWrapperFunctions: [
-      'forbidExtraProps'
-    ]
+    propWrapperFunctions: ['forbidExtraProps']
   },
   globals: {
     chai: true,
@@ -44,25 +37,16 @@ module.exports = {
   },
   rules: {
     'block-scoped-var': 'error',
-    'complexity': [
-      'error',
-      9
-    ],
-    'eol-last': [
-      'error',
-      'always'
-    ],
-    'indent': [
+    complexity: ['error', 9],
+    'eol-last': ['error', 'always'],
+    indent: [
       'error',
       2,
       {
-        'SwitchCase': 1
+        SwitchCase: 1
       }
     ],
-    'linebreak-style': [
-      'error',
-      'unix'
-    ],
+    'linebreak-style': ['error', 'unix'],
     'no-eval': 'error',
     'no-eq-null': 'error',
     'no-multiple-empty-lines': [
@@ -72,66 +56,27 @@ module.exports = {
         maxEOF: 1
       }
     ],
-    'no-shadow': [
-      'error'
-    ],
-    'no-shadow-restricted-names': [
-      'error'
-    ],
+    'no-shadow': ['error'],
+    'no-shadow-restricted-names': ['error'],
     'no-trailing-spaces': 'error',
     'no-unused-vars': [
       'error',
       {
-        'varsIgnorePattern': '^_',
-        'argsIgnorePattern': '^_'
+        varsIgnorePattern: '^_',
+        argsIgnorePattern: '^_'
       }
     ],
     'no-use-before-define': 'error',
     'no-useless-return': 'error',
     'no-var': 'error',
-    'object-curly-spacing': [
-      'error',
-      'always'
-    ],
-    'object-shorthand': [
-      'error',
-      'never'
-    ],
-    'padded-blocks': [
-      'error',
-      'never'
-    ],
-    'quotes': [
-      'error',
-      'single'
-    ],
-    'semi': [
-      'error',
-      'always'
-    ],
-    'strict': [
-      'error',
-      'global'
-    ],
+    'object-curly-spacing': ['error', 'always'],
+    'object-shorthand': ['error', 'never'],
+    'padded-blocks': ['error', 'never'],
+    quotes: ['error', 'single'],
+    semi: ['error', 'always'],
+    strict: ['error', 'global'],
     'comma-dangle': ['error', 'never'],
-    'arrow-parens': ['error', 'as-needed'],
-    'padding-line-between-statements': [
-      'error',
-      // Declarations
-      { blankLine: 'always', prev: ['const', 'let', 'var'], next: '*' },
-      { blankLine: 'never', prev: ['const', 'let', 'var'], next: ['const', 'let', 'var'] },
-      { blankLine: 'always', prev: ['multiline-block-like', 'multiline-expression'], next: ['const', 'let', 'var'] },
-      { blankLine: 'always', prev: ['const', 'let', 'var'], next: ['multiline-block-like', 'multiline-expression'] },
-      // Expressions
-      { blankLine: 'always', prev: 'expression', next: '*' },
-      { blankLine: 'any', prev: 'expression', next: 'expression', },
-      { blankLine: 'always', prev: ['multiline-block-like', 'multiline-expression'], next: 'expression', },
-      { blankLine: 'always', prev: 'expression', next: ['multiline-block-like', 'multiline-expression'] },
-      // Switches
-      { blankLine: 'always', prev: ['while', 'if', 'for', 'switch'], next: '*' },
-      // Return
-      { blankLine: 'always', prev: 'return', next: '*' },
-      { blankLine: 'always', prev: '*', next: 'return' },
-    ]
+    'arrow-parens': ['error', 'always'],
+    'padding-line-between-statements': 'off'
   }
 };

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ module.exports = {
     'no-useless-return': 'error',
     'no-var': 'error',
     'object-curly-spacing': ['error', 'always'],
-    'object-shorthand': ['error', 'never'],
+    'object-shorthand': ['error', 'always'],
     'padded-blocks': ['error', 'never'],
     quotes: ['error', 'single'],
     semi: ['error', 'always'],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-sem",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "main": "index.js",
   "license": "MIT",
   "author": "OnlineDev Backend",


### PR DESCRIPTION
Use JS standard formatting for spacing as this is more pain than its worth, Also set arrow-parens to always as to only not require them on single argument function calls is weird.

These are the defaults utilised by airbnb-config